### PR TITLE
Bump AWS SDK to v3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,20 +2,26 @@ PATH
   remote: .
   specs:
     deb-s3 (0.11.1)
-      aws-sdk (~> 2)
+      aws-sdk-s3 (~> 1)
       thor (~> 0.19.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-sdk (2.11.545)
-      aws-sdk-resources (= 2.11.545)
-    aws-sdk-core (2.11.545)
-      aws-sigv4 (~> 1.0)
+    aws-partitions (1.351.0)
+    aws-sdk-core (3.104.3)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-resources (2.11.545)
-      aws-sdk-core (= 2.11.545)
+    aws-sdk-kms (1.36.0)
+      aws-sdk-core (~> 3, >= 3.99.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-s3 (1.75.0)
+      aws-sdk-core (~> 3, >= 3.104.1)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.1)
       aws-eventstream (~> 1, >= 1.0.2)
     jmespath (1.4.0)
@@ -32,4 +38,4 @@ DEPENDENCIES
   rake (>= 12.3.3)
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/deb-s3.gemspec
+++ b/deb-s3.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.required_ruby_version = '>= 1.9.3'
 
   gem.add_dependency "thor",    "~> 0.19.0"
-  gem.add_dependency "aws-sdk", "~> 2"
+  gem.add_dependency "aws-sdk-s3", "~> 1"
   gem.add_development_dependency "minitest", "~> 5"
   gem.add_development_dependency "rake", "~> 11"
 end

--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -1,5 +1,5 @@
 # -*- encoding : utf-8 -*-
-require "aws-sdk"
+require "aws-sdk-s3"
 require "thor"
 
 # Hack: aws requires this!


### PR DESCRIPTION
The v2 SDK is deprecated but the v3 SDK has no breaking changes.

The SDK is now modularised into service specific gems so we don't have to pull the whole thing in.

Not sure I've done this right but I think this is probably what's wanted now that we don't need the whole SDK.

Closes #1 


