### PR TITLE
Ruby 3.0 compatibility

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -253,7 +253,7 @@ class Deb::S3::Package
 
     # Packages manifest fields
     filename = fields.delete('Filename')
-    self.url_filename = filename && URI.unescape(filename)
+    self.url_filename = filename && CGI.unescape(filename)
     self.sha1 = fields.delete('SHA1')
     self.sha256 = fields.delete('SHA256')
     self.md5 = fields.delete('MD5sum')


### PR DESCRIPTION
URI.unescape was deprecated since Ruby 1.9.2, and is now removed from Ruby 3.0.
More info: https://stackoverflow.com/questions/2824126/whats-the-difference-between-uri-escape-and-cgi-escape