### PR TITLE
FIx URI.unescape is obsolete (#6)

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -253,7 +253,7 @@ class Deb::S3::Package
 
     # Packages manifest fields
     filename = fields.delete('Filename')
-    self.url_filename = filename && URI.unescape(filename)
+    self.url_filename = filename && URI.decode_www_form_component(filename)
     self.sha1 = fields.delete('SHA1')
     self.sha256 = fields.delete('SHA256')
     self.md5 = fields.delete('MD5sum')


### PR DESCRIPTION
Fixes #6 by replacing URI.unescape with [decode_www_form_component](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI.html#method-c-decode_www_form_component) (as suggested in [ruby-doc](https://ruby-doc.org/stdlib-2.7.0/libdoc/uri/rdoc/URI/Escape.html#method-i-unescape-label-Synopsis)).