### PR TITLE
Fix warnings from minitest; fix methods redefined warnings

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -30,7 +30,6 @@ class Deb::S3::Package
   attr_accessor :attributes
 
   # hashes
-  attr_accessor :url_filename
   attr_accessor :sha1
   attr_accessor :sha256
   attr_accessor :md5
@@ -133,11 +132,10 @@ class Deb::S3::Package
     [[epoch, version].compact.join(":"), iteration].compact.join("-")
   end
 
-  def filename=(f)
-    @filename = f
-    @filename
+  def url_filename=(f)
+    @url_filename = f
   end
-
+  
   def url_filename(codename)
     @url_filename || "pool/#{codename}/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
   end

--- a/spec/deb/s3/lock_spec.rb
+++ b/spec/deb/s3/lock_spec.rb
@@ -7,12 +7,12 @@ describe Deb::S3::Lock do
   describe :locked? do
     it 'returns true if lock file exists' do
       Deb::S3::Utils.stub :s3_exists?, true do
-        Deb::S3::Lock.locked?("stable").must_equal true
+        _(Deb::S3::Lock.locked?("stable")).must_equal true
       end
     end
     it 'returns true if lock file exists' do
       Deb::S3::Utils.stub :s3_exists?, false do
-        Deb::S3::Lock.locked?("stable").must_equal false
+        _(Deb::S3::Lock.locked?("stable")).must_equal false
       end
     end
   end
@@ -49,15 +49,15 @@ describe Deb::S3::Lock do
     end
 
     it 'returns a lock object' do
-      @lock.must_be_instance_of Deb::S3::Lock
+      _(@lock).must_be_instance_of Deb::S3::Lock
     end
 
     it 'holds the user who currently holds the lock' do
-      @lock.user.must_equal 'alex'
+      _(@lock.user).must_equal 'alex'
     end
 
     it 'holds the hostname from where the lock was set' do
-      @lock.host.must_equal 'localhost'
+      _(@lock.host).must_equal 'localhost'
     end
   end
 

--- a/spec/deb/s3/manifest_spec.rb
+++ b/spec/deb/s3/manifest_spec.rb
@@ -15,7 +15,7 @@ describe Deb::S3::Manifest do
 
       @manifest.stub :packages, [existing_package_with_same_full_version] do
         @manifest.add(new_package, preserve_versions=true)
-        @manifest.packages.length.must_equal 1
+        _(@manifest.packages.length).must_equal 1
       end
     end
 
@@ -25,7 +25,7 @@ describe Deb::S3::Manifest do
 
       @manifest.stub :packages, [existing_package_with_same_version] do
         @manifest.add(new_package, preserve_versions=true)
-        @manifest.packages.length.must_equal 2
+        _(@manifest.packages.length).must_equal 2
       end
     end
 
@@ -39,7 +39,7 @@ describe Deb::S3::Manifest do
 
       @manifest.stub :packages, existing_packages_with_same_name do
         @manifest.add(new_package, preserve_versions=false)
-        @manifest.packages.must_equal [new_package]
+        _(@manifest.packages).must_equal [new_package]
       end
     end
   end
@@ -61,7 +61,7 @@ describe Deb::S3::Manifest do
       @manifest.instance_variable_set(:@packages, existing_packages_with_same_version + existing_packages_with_different_version)
 
       @manifest.delete_package("discourse", versions_to_delete)
-      @manifest.packages.must_equal existing_packages_with_different_version
+      _(@manifest.packages).must_equal existing_packages_with_different_version
 
       # Reset the attribute
       @manifest.instance_variable_set(:@packages, [])

--- a/spec/deb/s3/package_spec.rb
+++ b/spec/deb/s3/package_spec.rb
@@ -8,40 +8,40 @@ describe Deb::S3::Package do
   describe ".parse_string" do
     it "creates a Package object with the right attributes" do
       package = Deb::S3::Package.parse_string(File.read(fixture("Packages")))
-      package.version.must_equal("0.9.8.3")
-      package.epoch.must_equal(nil)
-      package.iteration.must_equal("1396474125.12e4179.wheezy")
-      package.full_version.must_equal("0.9.8.3-1396474125.12e4179.wheezy")
-      package.description.must_equal(EXPECTED_DESCRIPTION)
+      _(package.version).must_equal("0.9.8.3")
+      assert_nil(package.epoch)
+      _(package.iteration).must_equal("1396474125.12e4179.wheezy")
+      _(package.full_version).must_equal("0.9.8.3-1396474125.12e4179.wheezy")
+      _(package.description).must_equal(EXPECTED_DESCRIPTION)
     end
   end
 
   describe "#full_version" do
     it "returns nil if no version, epoch, iteration" do
       package = create_package
-      package.full_version.must_equal nil
+      assert_nil(package.full_version)
     end
 
     it "returns only the version if no epoch and no iteration" do
       package = create_package :version => "0.9.8"
-      package.full_version.must_equal "0.9.8"
+      _(package.full_version).must_equal "0.9.8"
     end
 
     it "returns epoch:version if epoch and version" do
       epoch = Time.now.to_i
       package = create_package :version => "0.9.8", :epoch => epoch
-      package.full_version.must_equal "#{epoch}:0.9.8"
+      _(package.full_version).must_equal "#{epoch}:0.9.8"
     end
 
     it "returns version-iteration if version and iteration" do
       package = create_package :version => "0.9.8", :iteration => "2"
-      package.full_version.must_equal "0.9.8-2"
+      _(package.full_version).must_equal "0.9.8-2"
     end
 
     it "returns epoch:version-iteration if epoch and version and iteration" do
       epoch = Time.now.to_i
       package = create_package :version => "0.9.8", :iteration => "2", :epoch => epoch
-      package.full_version.must_equal "#{epoch}:0.9.8-2"
+      _(package.full_version).must_equal "#{epoch}:0.9.8-2"
     end
   end
 end


### PR DESCRIPTION
Minitest has some deprecation warnings:

```

DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/manifest_spec.rb:64. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/lock_spec.rb:15. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/lock_spec.rb:10. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/lock_spec.rb:60. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_be_instance_of from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/lock_spec.rb:52. Use _(obj).must_be_instance_of instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/lock_spec.rb:56. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/manifest_spec.rb:18. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/manifest_spec.rb:28. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/manifest_spec.rb:42. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:44. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:22. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: Use assert_nil if expecting nil from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:22. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:38. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:27. Use _(obj).must_equal instead. This will fail in Minitest 6.
.DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:33. Use _(obj).must_equal instead. This will fail in Minitest 6.
../Users/aakatev/Documents/personal/deb-s3/lib/deb/s3/package.rb:256: warning: URI.unescape is obsolete
DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:11. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:12. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: Use assert_nil if expecting nil from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:12. This will fail in Minitest 6.
DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:13. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:14. Use _(obj).must_equal instead. This will fail in Minitest 6.
DEPRECATED: global use of must_equal from /Users/aakatev/Documents/personal/deb-s3/spec/deb/s3/package_spec.rb:15. Use _(obj).must_equal instead. This will fail in Minitest 6.
```

This PR fixes them.

---

I also include with the following commit fixes for these warnings:

```
/Users/aakatev/Documents/personal/deb-s3/lib/deb/s3/package.rb:136: warning: method redefined; discarding old url_filename=
/Users/aakatev/Documents/personal/deb-s3/lib/deb/s3/package.rb:140: warning: method redefined; discarding old url_filename
```

The methods were created by specifying `attr_accessor`, but removed overwritten by custom behavior. In case of `filename=`, it is not get used anywhere else in the code, so there is no need for it. 