### PR TITLE
Do not do unnecessary escapes

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -574,7 +574,7 @@ class Deb::S3::CLI < Thor
       missing_packages = []
 
       manifest.packages.each do |p|
-        unless Deb::S3::Utils.s3_exists? p.url_filename_encoded(options[:codename])
+        unless Deb::S3::Utils.s3_exists? p.url_filename(options[:codename])
           sublog("The following packages are missing:\n\n") if missing_packages.empty?
           puts(p.generate(options[:codename]))
           puts("")

--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -144,10 +144,6 @@ class Deb::S3::Package
     @url_filename || "pool/#{codename}/#{self.name[0]}/#{self.name[0..1]}/#{File.basename(self.filename)}"
   end
 
-  def url_filename_encoded(codename)
-    @url_filename || "pool/#{codename}/#{self.name[0]}/#{self.name[0..1]}/#{s3_escape(File.basename(self.filename))}"
-  end
-
   def generate(codename)
     template("package.erb").result(binding)
   end
@@ -254,8 +250,7 @@ class Deb::S3::Package
     self.attributes[:deb_installed_size] = fields.delete('Installed-Size')
 
     # Packages manifest fields
-    filename = fields.delete('Filename')
-    self.url_filename = filename && CGI.unescape(filename)
+    self.url_filename = fields.delete('Filename')
     self.sha1 = fields.delete('SHA1')
     self.sha256 = fields.delete('SHA256')
     self.md5 = fields.delete('MD5sum')

--- a/lib/deb/s3/templates/package.erb
+++ b/lib/deb/s3/templates/package.erb
@@ -40,7 +40,7 @@ Origin: <%= attributes[:deb_origin] %>
 <% end -%>
 Priority: <%= attributes[:deb_priority] %>
 Homepage: <%= url or "http://nourlgiven.example.com/" %>
-Filename: <%= url_filename_encoded(codename) %>
+Filename: <%= url_filename(codename) %>
 <% if size -%>
 Size: <%= size %>
 <% end -%>


### PR DESCRIPTION
Apt does handle downloads correctly without these modifications on the "Packages" manifest.

Also, the usage of different methods on encode and decode lead to interesting problems with corrupted urls.

Fixes #11 .

Tested on Debian bookworm Docker container running in CircleCI. Generated:
```
Package: cutie-shell
Version: 0.0.3+git20221218211230.9147c27.bookworm
License: unknown
Vendor: none
Architecture: arm64
Maintainer: Erik Inkinen <erik.inkinen@gmail.com>
Installed-Size: 3077
Depends: libc6 (>= 2.34), libgcc-s1 (>= 3.0), libqt5core5a (>= 5.15.1), libqt5dbus5 (>= 5.0.2), libqt5gui5 (>= 5.0.2) | libqt5gui5-gles (>= 5.0.2), libqt5qml5 (>= 5.1.0), libstdc++6 (>= 4.1.1), cutie-settings-daemon, qml-module-qtquick2, qml-module-qtquick-controls, qml-module-qtquick-controls2, qml-module-qtsensors, qml-module-qtwayland-compositor
Section: libs
Priority: optional
Homepage: http://nourlgiven.example.com/
Filename: pool/bookworm/c/cu/cutie-shell_0.0.3+git20221218211230.9147c27.bookworm_arm64.deb
Size: 1864084
SHA1: e16c6b0c25a83acf7cbd3f21d5fabbae304cc80e
SHA256: e36f63739c99defc2d237eaaa954354173309f96c9dc15c3600a4238b3cce8c4
MD5sum: 8c3d38625153625c5e1ea7431f9c26ee
Description: This package contains Cutie Shell.
Multi-Arch: foreign
```

Installation shows fetch working:
```
droidian@droidian:~$ sudo apt install cutie-shell
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  cutie-shell
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 1,864 kB of archives.
After this operation, 3,151 kB of additional disk space will be used.
Get:1 http://deb.cutie-shell.org/staging bookworm/main arm64 cutie-shell arm64 0.0.3+git20221218211230.9147c27.bookworm [1,864 kB]
Fetched 1,864 kB in 0s (4,586 kB/s)
debconf: unable to initialize frontend: Dialog
debconf: (No usable dialog-like program is installed, so the dialog based frontend cannot be used. at /usr/share/perl5/Debconf/FrontEnd/Dialog.pm line 78, <> line 1.)
debconf: falling back to frontend: Readline
Selecting previously unselected package cutie-shell.
(Reading database ... 97906 files and directories currently installed.)
Preparing to unpack .../cutie-shell_0.0.3+git20221218211230.9147c27.bookworm_arm64.deb ...
Unpacking cutie-shell (0.0.3+git20221218211230.9147c27.bookworm) ...
```
