### PR TITLE
Allow skipping placing an ACL

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Options:
                                                            # Default: us-east-1
       [--force-path-style], [--no-force-path-style]        # Use S3 path style instead of subdomains.
       [--proxy-uri=PROXY_URI]                              # The URI of the proxy to send service requests through.
-  -v, [--visibility=VISIBILITY]                            # The access policy for the uploaded files. Can be public, private, or authenticated.
+  -v, [--visibility=VISIBILITY]                            # The access policy for the uploaded files. Can be public, private, authenticated, or nil to avoid setting an ACL.
                                                            # Default: public
       [--sign=SIGN]                                        # GPG Sign the Release file when uploading a package, or when verifying it after removing a package. Use --sign with your GPG key ID to use a specific key (--sign=6643C242C18FE05B).
       [--gpg-options=GPG_OPTIONS]                          # Additional command line options to pass to GPG when signing.
@@ -282,3 +282,9 @@ Verifies that the files in the package manifests exist
     ]
 }
 ```
+
+## FAQ
+
+## "The bucket does not allow ACLs"
+
+Set visiblity to `nil` to avoid trying to set ACL: `--visibility=nil`. You will need to configure permissions through the bucket policy.

--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -83,7 +83,7 @@ class Deb::S3::CLI < Thor
   :type     => :string,
   :aliases  => "-v",
   :desc     => "The access policy for the uploaded files. " +
-    "Can be public, private, or authenticated."
+    "Can be public, private, authenticated, or nil to avoid setting an ACL."
 
   class_option :sign,
   :repeatable => true,
@@ -756,6 +756,8 @@ class Deb::S3::CLI < Thor
         "authenticated-read"
       when "bucket_owner"
         "bucket-owner-full-control"
+      when "nil"
+        nil
       else
         error("Invalid visibility setting given. Can be public, private, authenticated, or bucket_owner.")
       end

--- a/lib/deb/s3/utils.rb
+++ b/lib/deb/s3/utils.rb
@@ -86,10 +86,13 @@ module Deb::S3::Utils
     options = {
       :bucket => Deb::S3::Utils.bucket,
       :key => s3_path(filename),
-      :acl => Deb::S3::Utils.access_policy,
       :content_type => content_type,
       :metadata => { "md5" => file_md5.to_s },
     }
+
+    if !Deb::S3::Utils.access_policy.nil?
+      options[:acl] = Deb::S3::Utils.access_policy
+    end
     if !cache_control.nil?
       options[:cache_control] = cache_control
     end


### PR DESCRIPTION
[According to the ACL docs,](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html) 

> A majority of modern use cases in Amazon S3 no longer require the use of ACLs. We recommend that you keep ACLs disabled, except in unusual circumstances where you need to control access for each object individually.

This MR allows ACLs to not be placed.

Disclaimer: I've never written ruby before, and I have no idea how to test this. But this concept worked great when I tested it with a hacky patch: `sed -i 's/:acl => Deb::S3::Utils.access_policy,//g' /opt/hostedtoolcache/Ruby/*/x64/lib/ruby/gems/*/gems/deb-s3-*/lib/deb/s3/utils.rb`