### PR TITLE
Added Google Buckets support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ $ deb-s3 upload --bucket my-bucket my-deb-package-1.0.0_amd64.deb
 >> Update complete.
 ```
 
+For Google Cloud Storage (or other S3-compatible endpoints) you need to disable
+SDK checksum negotiation headers and set visbility settings to nil:
+
+```console
+$ deb-s3 upload --bucket my-bucket --endpoint https://storage.googleapis.com --checksum-when-required --visibility nil my-deb-package-1.0.0_amd64.deb 
+```
+
+This flag keeps uploads on the same PutObject code path, but configures the AWS SDK
+to only send request checksums when required by the API.
+
 ```
 Usage:
   deb-s3 upload FILES

--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -118,6 +118,11 @@ class Deb::S3::CLI < Thor
   :aliases  => "-C",
   :desc     => "Add cache-control headers to S3 objects."
 
+  class_option :checksum_when_required,
+  :default  => false,
+  :type     => :boolean,
+  :desc     => "Disable SDK upload checksums for S3-compatible endpoints (for example Google Cloud Storage)."
+
   desc "upload FILES",
   "Uploads the given files to a S3 bucket as an APT repository."
 
@@ -776,6 +781,10 @@ class Deb::S3::CLI < Thor
       :force_path_style => options[:force_path_style]
     }
     settings[:endpoint] = options[:endpoint] if options[:endpoint]
+    if options[:checksum_when_required]
+      # GCS can reject AWS SDK checksum negotiation headers for PutObject.
+      settings[:request_checksum_calculation] = "when_required"
+    end
     settings.merge!(provider)
 
     Deb::S3::Utils.s3           = Aws::S3::Client.new(settings)

--- a/spec/deb/s3/cli_spec.rb
+++ b/spec/deb/s3/cli_spec.rb
@@ -1,0 +1,61 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'deb/s3/cli'
+
+describe Deb::S3::CLI do
+  def base_options(overrides = {})
+    {
+      :bucket => "test-bucket",
+      :s3_region => "us-east-1",
+      :proxy_uri => nil,
+      :force_path_style => false,
+      :endpoint => nil,
+      :access_key_id => nil,
+      :secret_access_key => nil,
+      :session_token => nil,
+      :sign => nil,
+      :gpg_provider => "gpg",
+      :gpg_options => "",
+      :prefix => nil,
+      :encryption => false,
+      :visibility => "public",
+      :checksum_when_required => false,
+    }.merge(overrides)
+  end
+
+  describe "#configure_s3_client" do
+    it "configures request checksum calculation when checksum_when_required is enabled" do
+      cli = Deb::S3::CLI.new
+      captured_settings = nil
+      fake_client = Object.new
+
+      cli.stub :options, base_options(:checksum_when_required => true) do
+        Aws::S3::Client.stub :new, lambda { |settings|
+          captured_settings = settings
+          fake_client
+        } do
+          cli.send(:configure_s3_client)
+        end
+      end
+
+      _(captured_settings[:request_checksum_calculation]).must_equal "when_required"
+      _(Deb::S3::Utils.s3).must_equal fake_client
+    end
+
+    it "does not override request checksum calculation by default" do
+      cli = Deb::S3::CLI.new
+      captured_settings = nil
+
+      cli.stub :options, base_options do
+        Aws::S3::Client.stub :new, lambda { |settings|
+          captured_settings = settings
+          Object.new
+        } do
+          cli.send(:configure_s3_client)
+        end
+      end
+
+      _(captured_settings.key?(:request_checksum_calculation)).must_equal false
+    end
+  end
+end


### PR DESCRIPTION
I added logic to support Google Buckets 

Previously attempt to upload to Google Bucket failed with following error:
```
 bin/deb-s3 upload --access-key-id=xxxx --secret-access-key=xxxx   --bucket debs3testrepo   ~/Downloads/steam_latest.deb --endpoint=https://storage.googleapis.com 
 
>> Retrieving existing manifests
>> Examining package file steam_latest.deb
>> Uploading packages and new manifests to S3
   -- Transferring dists/stable/main/binary-amd64/Packages
/var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call': Invalid argument. (Aws::S3::Errors::InvalidArgument)
	from /var/lib/gems/3.2.0/gems/aws-sdk-s3-1.152.2/lib/aws-sdk-s3/plugins/sse_cpk.rb:24:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-s3-1.152.2/lib/aws-sdk-s3/plugins/dualstack.rb:21:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-s3-1.152.2/lib/aws-sdk-s3/plugins/accelerate.rb:43:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/aws-sdk-core/plugins/checksum_algorithm.rb:111:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:16:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/aws-sdk-core/plugins/invocation_id.rb:16:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/aws-sdk-core/plugins/idempotency_token.rb:19:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/aws-sdk-core/plugins/param_converter.rb:26:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/seahorse/client/plugins/request_callback.rb:89:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/seahorse/client/plugins/response_target.rb:24:in `call'
	from /var/lib/gems/3.2.0/gems/aws-sdk-core-3.197.0/lib/seahorse/client/request.rb:72:in `send_request'
	from /var/lib/gems/3.2.0/gems/aws-sdk-s3-1.152.2/lib/aws-sdk-s3/client.rb:15616:in `put_object'
	from /home/pavel/repo/deb-s3/lib/deb/s3/utils.rb:106:in `block in s3_store'
	from /home/pavel/repo/deb-s3/lib/deb/s3/utils.rb:104:in `open'
	from /home/pavel/repo/deb-s3/lib/deb/s3/utils.rb:104:in `s3_store'
	from /home/pavel/repo/deb-s3/lib/deb/s3/manifest.rb:119:in `write_to_s3'
	from /home/pavel/repo/deb-s3/lib/deb/s3/cli.rb:245:in `block in upload'
	from /home/pavel/repo/deb-s3/lib/deb/s3/cli.rb:243:in `each_value'
	from /home/pavel/repo/deb-s3/lib/deb/s3/cli.rb:243:in `upload'
	from /var/lib/gems/3.2.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
	from /var/lib/gems/3.2.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
	from /var/lib/gems/3.2.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
	from /var/lib/gems/3.2.0/gems/thor-1.3.1/lib/thor/base.rb:584:in `start'
	from bin/deb-s3:9:in `<main>'
```

I added flag --disable-multipart which needs to be combined with flag --visibility nil and now it works just fine:
```
AWS_ACCESS_KEY_ID="xxx" AWS_SECRET_ACCESS_KEY="xxx"   bin/deb-s3 upload --endpoint=https://storage.googleapis.com  --disable-multipart --bucket debs3testrepo  fastnetmon_2.0.375_amd64_12beb4c7fe4a0dec2201745d1d34993c5d1e3d30.deb  --visibility nil

>> Retrieving existing manifests
>> Examining package file fastnetmon_2.0.375_amd64_12beb4c7fe4a0dec2201745d1d34993c5d1e3d30.deb
>> Uploading packages and new manifests to S3
   -- Transferring pool/stable/f/fa/fastnetmon_2.0.375_amd64_12beb4c7fe4a0dec2201745d1d34993c5d1e3d30.deb
   -- Transferring dists/stable/main/binary-amd64/Packages
   -- Transferring dists/stable/main/binary-amd64/Packages.gz
   -- Transferring dists/stable/Release
>> Update complete.
```

Without flag --visibility nil  it will fail too with following error:
```
>> Examining package file fastnetmon_2.0.375_amd64_12beb4c7fe4a0dec2201745d1d34993c5d1e3d30.deb
>> Uploading packages and new manifests to S3
   -- Transferring pool/stable/f/fa/fastnetmon_2.0.375_amd64_12beb4c7fe4a0dec2201745d1d34993c5d1e3d30.deb
   -- Transferring dists/stable/main/binary-amd64/Packages
   -- Transferring dists/stable/main/binary-amd64/Packages.gz
   -- Transferring dists/stable/Release
/var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call': Invalid argument. (Aws::S3::Errors::InvalidArgument)
	from /var/lib/gems/3.3.0/gems/aws-sdk-s3-1.210.1/lib/aws-sdk-s3/plugins/sse_cpk.rb:24:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-s3-1.210.1/lib/aws-sdk-s3/plugins/dualstack.rb:21:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-s3-1.210.1/lib/aws-sdk-s3/plugins/accelerate.rb:43:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/checksum_algorithm.rb:167:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:16:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/invocation_id.rb:16:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/idempotency_token.rb:19:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/param_converter.rb:26:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/seahorse/client/plugins/request_callback.rb:89:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/seahorse/client/plugins/response_target.rb:24:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/telemetry.rb:39:in `block in call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/telemetry/no_op.rb:29:in `in_span'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/telemetry.rb:53:in `span_wrapper'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/aws-sdk-core/plugins/telemetry.rb:39:in `call'
	from /var/lib/gems/3.3.0/gems/aws-sdk-core-3.241.1/lib/seahorse/client/request.rb:72:in `send_request'
	from /var/lib/gems/3.3.0/gems/aws-sdk-s3-1.210.1/lib/aws-sdk-s3/client.rb:18508:in `put_object'
	from /home/pavel/repo/deb-s3/lib/deb/s3/utils.rb:108:in `block in s3_store'
	from /home/pavel/repo/deb-s3/lib/deb/s3/utils.rb:106:in `open'
	from /home/pavel/repo/deb-s3/lib/deb/s3/utils.rb:106:in `s3_store'
	from /home/pavel/repo/deb-s3/lib/deb/s3/release.rb:101:in `write_to_s3'
	from /home/pavel/repo/deb-s3/lib/deb/s3/cli.rb:263:in `upload'
	from /var/lib/gems/3.3.0/gems/thor-1.5.0/lib/thor/command.rb:28:in `run'
	from /var/lib/gems/3.3.0/gems/thor-1.5.0/lib/thor/invocation.rb:127:in `invoke_command'
	from /var/lib/gems/3.3.0/gems/thor-1.5.0/lib/thor.rb:538:in `dispatch'
	from /var/lib/gems/3.3.0/gems/thor-1.5.0/lib/thor/base.rb:585:in `start'
	from bin/deb-s3:9:in `<main>'

```

Please note that code was created with assistance of AI GPT-5.3-Codex