### PR TITLE
Add prune command for bulk package version cleanup

### DIFF
--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -592,6 +592,151 @@ class Deb::S3::CLI < Thor
   end
 
 
+  desc "prune",
+    "Remove old package versions from the repository. At least one of " +
+    "--keep-latest or --below-version must be specified. A version is " +
+    "removed if ANY rule flags it for pruning."
+
+  option :arch,
+    :type     => :string,
+    :aliases  => "-a",
+    :desc     => "The architecture to prune. If not specified or 'all', " +
+      "prunes across all architectures."
+
+  option :lock,
+    :default  => false,
+    :type     => :boolean,
+    :aliases  => "-l",
+    :desc     => "Whether to check for an existing lock on the repository " +
+      "to prevent simultaneous updates "
+
+  option :keep_latest,
+    :type     => :numeric,
+    :desc     => "Keep only the N most recent versions of each package."
+
+  option :below_version,
+    :type     => :string,
+    :desc     => "Remove all versions below this Debian version string."
+
+  option :package,
+    :type     => :string,
+    :desc     => "Only prune packages matching this name (glob pattern with * and ?)."
+
+  option :dry_run,
+    :default  => false,
+    :type     => :boolean,
+    :desc     => "Show what would be removed without actually deleting."
+
+  def prune
+    keep_latest = options[:keep_latest]
+    below_version = options[:below_version]
+
+    if keep_latest.nil? && below_version.nil?
+      error("You must specify at least one of --keep-latest or --below-version.")
+    end
+
+    if keep_latest && keep_latest < 1
+      error("--keep-latest must be at least 1.")
+    end
+
+    configure_s3_client
+
+    begin
+      if options[:lock]
+        log("Checking for existing lock file")
+        log("Locking repository for updates")
+        Deb::S3::Lock.lock(options[:codename], component, options[:arch], options[:cache_control])
+        @lock_acquired = true
+      end
+
+      log("Retrieving existing manifests")
+      release = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite])
+
+      arch = options[:arch]
+      if arch.nil? || arch == "all"
+        selected_archs = release.architectures
+      else
+        selected_archs = [arch]
+      end
+
+      total_pruned = 0
+
+      selected_archs.each do |ar|
+        manifest = Deb::S3::Manifest.retrieve(options[:codename], component, ar, options[:cache_control], false)
+
+        # Group packages by name
+        by_name = {}
+        manifest.packages.each do |pkg|
+          next if options[:package] && !File.fnmatch(options[:package], pkg.name)
+          by_name[pkg.name] ||= []
+          by_name[pkg.name] << pkg
+        end
+
+        to_remove = []
+
+        by_name.each do |name, pkgs|
+          # Sort by version descending (newest first)
+          sorted = pkgs.sort { |a, b|
+            Deb::S3::Package.compare_versions(b.full_version, a.full_version)
+          }
+
+          sorted.each_with_index do |pkg, idx|
+            dominated = false
+
+            # Rule: keep only N latest
+            if keep_latest && idx >= keep_latest
+              dominated = true
+            end
+
+            # Rule: remove below version threshold
+            if below_version && Deb::S3::Package.compare_versions(pkg.full_version, below_version) < 0
+              dominated = true
+            end
+
+            to_remove << pkg if dominated
+          end
+        end
+
+        if to_remove.empty?
+          log("No packages to prune in arch #{ar}.")
+          next
+        end
+
+        to_remove.each do |pkg|
+          if options[:dry_run]
+            sublog("[dry-run] Would remove #{pkg.name} #{pkg.full_version} (#{ar})")
+          else
+            sublog("Removing #{pkg.name} #{pkg.full_version} (#{ar})")
+          end
+        end
+
+        total_pruned += to_remove.length
+
+        unless options[:dry_run]
+          to_remove.each { |pkg| manifest.packages.delete(pkg) }
+
+          log("Uploading new manifests to S3")
+          manifest.write_to_s3 { |f| sublog("Transferring #{f}") }
+          release.update_manifest(manifest)
+          release.write_to_s3 { |f| sublog("Transferring #{f}") }
+        end
+      end
+
+      if total_pruned == 0
+        log("Nothing to prune.")
+      elsif options[:dry_run]
+        log("Dry run complete. #{total_pruned} package(s) would be pruned.")
+      else
+        log("Prune complete. #{total_pruned} package(s) removed.")
+      end
+    ensure
+      if options[:lock] && @lock_acquired
+        Deb::S3::Lock.unlock(options[:codename], component, options[:arch], options[:cache_control])
+        log("Lock released.")
+      end
+    end
+  end
+
   desc "verify", "Verifies that the files in the package manifests exist"
 
   option :fix_manifests,

--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -283,6 +283,111 @@ class Deb::S3::Package
     self.md5 = Digest::MD5.file(file).hexdigest
   end
 
+  # Compare two Debian version strings using dpkg-compatible ordering.
+  # Returns -1, 0, or 1.
+  def self.compare_versions(a, b)
+    return 0 if a == b
+
+    ea, va, ia = split_full_version(a)
+    eb, vb, ib = split_full_version(b)
+
+    r = ea <=> eb
+    return r unless r == 0
+
+    r = compare_version_part(va, vb)
+    return r unless r == 0
+
+    compare_version_part(ia, ib)
+  end
+
+  # Parse "epoch:upstream-revision" into [epoch, upstream, revision]
+  def self.split_full_version(v)
+    v = v.to_s
+    if v =~ /^(\d+):(.+)$/
+      epoch = $1.to_i
+      rest = $2
+    else
+      epoch = 0
+      rest = v
+    end
+
+    if rest =~ /^(.+)-([^-]+)$/
+      upstream = $1
+      revision = $2
+    else
+      upstream = rest
+      revision = "0"
+    end
+
+    [epoch, upstream, revision]
+  end
+
+  # Compare non-epoch version parts per Debian policy §5.6.12
+  def self.compare_version_part(a, b)
+    a_segs = tokenize_version(a)
+    b_segs = tokenize_version(b)
+
+    max = [a_segs.length, b_segs.length].max
+    max.times do |i|
+      a_tok = a_segs[i]
+      b_tok = b_segs[i]
+
+      if i.even?
+        # non-digit segment
+        r = compare_lexical(a_tok || "", b_tok || "")
+      else
+        # digit segment
+        r = (a_tok || "0").to_i <=> (b_tok || "0").to_i
+      end
+      return r unless r == 0
+    end
+    0
+  end
+
+  # Split version part into alternating [non-digit, digit, non-digit, digit, ...]
+  def self.tokenize_version(v)
+    tokens = []
+    while v && !v.empty?
+      # non-digit prefix
+      if v =~ /^([^0-9]*)/
+        tokens << $1
+        v = v[$1.length..]
+      end
+      # digit prefix
+      if v && v =~ /^([0-9]*)/
+        tokens << $1
+        v = v[$1.length..]
+      end
+    end
+    tokens
+  end
+
+  # Lexical comparison modified per Debian policy:
+  # ~ sorts before everything (including end of string),
+  # letters sort before non-letters
+  def self.compare_lexical(a, b)
+    max = [a.length, b.length].max
+    max.times do |i|
+      ac = i < a.length ? a[i] : nil
+      bc = i < b.length ? b[i] : nil
+      r = version_char_order(ac) <=> version_char_order(bc)
+      return r unless r == 0
+    end
+    0
+  end
+
+  def self.version_char_order(c)
+    if c.nil?
+      0     # end of string
+    elsif c == '~'
+      -1    # sorts before everything
+    elsif c =~ /[a-zA-Z]/
+      c.ord # 65-122, before non-letters
+    else
+      c.ord + 256
+    end
+  end
+
   def parse_control(control)
     field = nil
     value = ""

--- a/spec/deb/s3/package_spec.rb
+++ b/spec/deb/s3/package_spec.rb
@@ -16,6 +16,49 @@ describe Deb::S3::Package do
     end
   end
 
+  describe ".compare_versions" do
+    it "compares simple versions" do
+      _(Deb::S3::Package.compare_versions("1.0", "2.0")).must_equal(-1)
+      _(Deb::S3::Package.compare_versions("2.0", "1.0")).must_equal(1)
+      _(Deb::S3::Package.compare_versions("1.0", "1.0")).must_equal(0)
+    end
+
+    it "compares numeric segments properly (not lexicographic)" do
+      _(Deb::S3::Package.compare_versions("1.10", "1.9")).must_equal(1)
+      _(Deb::S3::Package.compare_versions("2.0.0", "1.99.99")).must_equal(1)
+    end
+
+    it "handles epochs" do
+      _(Deb::S3::Package.compare_versions("1:1.0", "2.0")).must_equal(1)
+      _(Deb::S3::Package.compare_versions("0:1.0", "1.0")).must_equal(0)
+      _(Deb::S3::Package.compare_versions("1:0.1", "2:0.1")).must_equal(-1)
+    end
+
+    it "handles revisions" do
+      _(Deb::S3::Package.compare_versions("1.0-1", "1.0-2")).must_equal(-1)
+      _(Deb::S3::Package.compare_versions("1.0-1", "1.0-1")).must_equal(0)
+      _(Deb::S3::Package.compare_versions("1.0-10", "1.0-9")).must_equal(1)
+    end
+
+    it "handles tilde (sorts before everything)" do
+      _(Deb::S3::Package.compare_versions("1.0~beta", "1.0")).must_equal(-1)
+      _(Deb::S3::Package.compare_versions("1.0~alpha", "1.0~beta")).must_equal(-1)
+      _(Deb::S3::Package.compare_versions("1.0~rc1", "1.0")).must_equal(-1)
+    end
+
+    it "handles equal versions" do
+      _(Deb::S3::Package.compare_versions("1.0-1", "1.0-1")).must_equal(0)
+      _(Deb::S3::Package.compare_versions("1:2.3-4", "1:2.3-4")).must_equal(0)
+    end
+
+    it "handles real-world mina-style versions" do
+      _(Deb::S3::Package.compare_versions(
+        "3.0.8.4-1.1.4bullseye",
+        "3.0.9.0-1.1.0bullseye"
+      )).must_equal(-1)
+    end
+  end
+
   describe "#full_version" do
     it "returns nil if no version, epoch, iteration" do
       package = create_package


### PR DESCRIPTION
## Summary
- Adds a new `prune` command to bulk-remove old package versions from the repository
- Supports `--keep-latest N` (retain N newest versions per package) and `--below-version V` (remove versions below threshold)
- Includes `--dry-run` mode, `--package` glob filtering, and per-arch targeting
- Implements dpkg-compatible Debian version comparison (epochs, tildes, numeric segments)
- Adds unit tests for version comparison logic

## Usage examples
```bash
# Preview: keep only 3 latest versions
deb-s3 prune --bucket=${bucket} --s3-region=us-west-2 \
  --codename noble --component stable --keep-latest 3 --dry-run

# Remove versions below 3.0.0 for mina-* packages
deb-s3 prune --bucket=${bucket} --s3-region=us-west-2 \
  --codename noble --component stable --below-version 3.0.0 \
  --package "mina-*"
```

## Test plan
- [x] Unit tests for Debian version comparison (7 test cases covering epochs, revisions, tildes, numeric ordering)
- [ ] Manual test with `--dry-run` against a real repository
- [ ] Manual test with actual pruning on a test repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)