### PR TITLE
Use compatible --zstd option for tar.

### DIFF
--- a/lib/deb/s3/package.rb
+++ b/lib/deb/s3/package.rb
@@ -68,7 +68,8 @@ class Deb::S3::Package
         if control_file === "control.tar.gz"
 	  compression = "z"
         elsif control_file === "control.tar.zst"
-          compression = "I zstd"
+          # Use the --zstd argument which appears to be supported both by GNU tar and bsdtar.
+          compression = "-zstd"
 	else
 	  compression = "J"
         end


### PR DESCRIPTION
Previously -I zstd was used for passing the archive through zstd decompression. This option is not available for bsdtar on Mac OS. Instead switch to use --zstd which is available both on GNU tar and bsdtar.