### PR TITLE
Add a label field to the release file

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Options:
   -b, [--bucket=BUCKET]                                    # The name of the S3 bucket to upload to.
       [--prefix=PREFIX]                                    # The path prefix to use when storing on S3.
   -o, [--origin=ORIGIN]                                    # The origin to use in the repository Release file.
+      [--label=LABEL]                                      # The label to use in the repository Release file.
       [--suite=SUITE]                                      # The suite to use in the repository Release file.
   -c, [--codename=CODENAME]                                # The codename of the APT repository.
                                                            # Default: stable
@@ -142,6 +143,7 @@ Options:
   -b, [--bucket=BUCKET]                              # The name of the S3 bucket to upload to.
       [--prefix=PREFIX]                              # The path prefix to use when storing on S3.
   -o, [--origin=ORIGIN]                              # The origin to use in the repository Release file.
+      [--label=LABEL]                                # The label to use in the repository Release file.
       [--suite=SUITE]                                # The suite to use in the repository Release file.
   -c, [--codename=CODENAME]                          # The codename of the APT repository.
                                                      # Default: stable
@@ -182,6 +184,7 @@ Options:
   -b, [--bucket=BUCKET]                              # The name of the S3 bucket to upload to.
       [--prefix=PREFIX]                              # The path prefix to use when storing on S3.
   -o, [--origin=ORIGIN]                              # The origin to use in the repository Release file.
+      [--label=LABEL]                                # The label to use in the repository Release file.
       [--suite=SUITE]                                # The suite to use in the repository Release file.
   -c, [--codename=CODENAME]                          # The codename of the APT repository.
                                                      # Default: stable
@@ -225,6 +228,7 @@ Options:
   -b, [--bucket=BUCKET]                              # The name of the S3 bucket to upload to.
       [--prefix=PREFIX]                              # The path prefix to use when storing on S3.
   -o, [--origin=ORIGIN]                              # The origin to use in the repository Release file.
+      [--label=LABEL]                                # The label to use in the repository Release file.
       [--suite=SUITE]                                # The suite to use in the repository Release file.
   -c, [--codename=CODENAME]                          # The codename of the APT repository.
                                                      # Default: stable

--- a/lib/deb/s3/cli.rb
+++ b/lib/deb/s3/cli.rb
@@ -27,6 +27,10 @@ class Deb::S3::CLI < Thor
   :aliases  => "-o",
   :desc     => "The origin to use in the repository Release file."
 
+  class_option :label,
+  :type     => :string,
+  :desc     => "The label to use in the repository Release file."
+
   class_option :suite,
   :type     => :string,
   :desc     => "The suite to use in the repository Release file."
@@ -181,7 +185,7 @@ class Deb::S3::CLI < Thor
 
       # retrieve the existing manifests
       log("Retrieving existing manifests")
-      release  = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite], options[:cache_control])
+      release  = Deb::S3::Release.retrieve(options[:codename], options[:origin], options[:suite], options[:cache_control], options[:label])
       manifests = {}
       release.architectures.each do |arch|
         manifests[arch] = Deb::S3::Manifest.retrieve(options[:codename], component, arch, options[:cache_control], options[:fail_if_exists], options[:skip_package_upload])

--- a/lib/deb/s3/release.rb
+++ b/lib/deb/s3/release.rb
@@ -6,6 +6,7 @@ class Deb::S3::Release
 
   attr_accessor :codename
   attr_accessor :origin
+  attr_accessor :label
   attr_accessor :suite
   attr_accessor :architectures
   attr_accessor :components
@@ -16,6 +17,7 @@ class Deb::S3::Release
 
   def initialize
     @origin = nil
+    @label = nil
     @suite = nil
     @codename = nil
     @architectures = []
@@ -26,7 +28,7 @@ class Deb::S3::Release
   end
 
   class << self
-    def retrieve(codename, origin=nil, suite=nil, cache_control=nil)
+    def retrieve(codename, origin=nil, suite=nil, cache_control=nil, label=nil)
       if s = Deb::S3::Utils.s3_read("dists/#{codename}/Release")
         rel = self.parse_release(s)
       else
@@ -35,6 +37,7 @@ class Deb::S3::Release
       rel.codename = codename
       rel.origin = origin unless origin.nil?
       rel.suite = suite unless suite.nil?
+      rel.label = label unless label.nil?
       rel.cache_control = cache_control
       rel
     end
@@ -63,6 +66,7 @@ class Deb::S3::Release
     # grab basic fields
     self.codename = parse.call("Codename")
     self.origin = parse.call("Origin") || nil
+    self.label = parse.call("Label") || nil
     self.suite = parse.call("Suite") || nil
     self.architectures = (parse.call("Architectures") || "").split(/\s+/)
     self.components = (parse.call("Components") || "").split(/\s+/)

--- a/lib/deb/s3/templates/release.erb
+++ b/lib/deb/s3/templates/release.erb
@@ -1,6 +1,9 @@
 <% if origin -%>
 Origin: <%= origin %>
 <% end -%>
+<% if label -%>
+Label: <%= label %>
+<% end -%>
 Codename: <%= codename %>
 Date: <%= Time.now.utc.strftime("%a, %d %b %Y %T %Z") %>
 Architectures: <%= architectures.join(" ") %>

--- a/spec/deb/s3/release_spec.rb
+++ b/spec/deb/s3/release_spec.rb
@@ -1,0 +1,68 @@
+# -*- encoding : utf-8 -*-
+require File.expand_path('../../../spec_helper', __FILE__)
+require 'deb/s3/utils'
+require 'deb/s3/release'
+
+describe Deb::S3::Release do
+  def release_text(fields)
+    fields.map { |k, v| "#{k}: #{v}" }.join("\n") + "\n"
+  end
+
+  describe "#parse" do
+    it "reads Label from an existing Release" do
+      rel = Deb::S3::Release.parse_release(release_text(
+        "Origin" => "public jammy",
+        "Label" => "public jammy",
+        "Codename" => "jammy",
+        "Suite" => "jammy",
+        "Architectures" => "amd64",
+        "Components" => "main",
+      ))
+      _(rel.label).must_equal "public jammy"
+    end
+
+    it "leaves Label nil when the Release has none" do
+      rel = Deb::S3::Release.parse_release(release_text(
+        "Codename" => "jammy",
+        "Architectures" => "amd64",
+        "Components" => "main",
+      ))
+      _(rel.label).must_be_nil
+    end
+  end
+
+  describe "#generate" do
+    it "emits Label when set" do
+      rel = Deb::S3::Release.new
+      rel.codename = "jammy"
+      rel.origin = "public jammy"
+      rel.label = "public jammy"
+      rel.suite = "jammy"
+      rel.architectures = ["amd64"]
+      rel.components = ["main"]
+      _(rel.generate).must_match(/^Label: public jammy$/)
+    end
+
+    it "omits the Label line entirely when unset" do
+      rel = Deb::S3::Release.new
+      rel.codename = "jammy"
+      rel.architectures = ["amd64"]
+      rel.components = ["main"]
+      _(rel.generate).wont_match(/^Label:/)
+    end
+
+    it "round-trips an existing Label through parse and generate" do
+      original = release_text(
+        "Origin" => "public jammy",
+        "Label" => "public jammy",
+        "Codename" => "jammy",
+        "Suite" => "jammy",
+        "Architectures" => "amd64",
+        "Components" => "main",
+      )
+      regenerated = Deb::S3::Release.parse_release(original).generate
+      _(regenerated).must_match(/^Label: public jammy$/)
+      _(regenerated).must_match(/^Origin: public jammy$/)
+    end
+  end
+end


### PR DESCRIPTION
This adds a `label` field for release files.

Currently this gem does not support labels. If a label is changed in a release apt blocks automatic updates for security concerns. This gem should support labels so that users can migrate DNS from another repo that uses release labels to a deb-s3 managed one and also to add the label release field to take advantage of that apt security use

I added tests and documentation of the label field as well